### PR TITLE
improved online indicator

### DIFF
--- a/dogegiftbot.py
+++ b/dogegiftbot.py
@@ -158,9 +158,13 @@ def getcost():
 def check_commands():
 	print 'Checking messages'
 	msgs = r.get_unread(limit=None)
+	
+
 	for msg in msgs:
+	        
 	        global balance
 	        global balance_message
+	        update_balance_db(float(balance),float(getcost()))
 	        if type(msg) != praw.objects.Message:
 	            msg.mark_as_read()
 	            print "NEW comment reply: ",

--- a/static/status.html
+++ b/static/status.html
@@ -4,7 +4,7 @@
 <div class="small-12 columns">
 <h3>DogeGiftBot Status</h3>
 
-{% if datetime.datetime.utcnow() - last_hist > datetime.timedelta(minutes = 20)%}
+{% if datetime.datetime.utcnow() - last_hist > datetime.timedelta(minutes = 30)%}
 <h4 style = "color:red"> Offline </h4>
 {%else%}
 <h4 style = "color:green"> Online </h4>

--- a/website.py
+++ b/website.py
@@ -106,16 +106,16 @@ class DogeTipBotBalance(BaseDBObject):
         self.lastUpdate = datetime.datetime.now()
         session.close()
     def getBalance(self):
-        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=5):
+        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=1):
             self.update()
         return self.balance
         
     def getCost(self):
-        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=5):
+        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=1):
             self.update()
         return self.cost
     def printBalance(self):
-        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=5):
+        if datetime.datetime.now() - self.lastUpdate > datetime.timedelta(minutes=1):
             self.update()
         bal = float(self.getBalance())
         cost = float(self.getCost())


### PR DESCRIPTION
previously the only way the online status was updated was if the bot received a history from dogetipbot. This caused the bot to show that if was offline if dogetipbot stopped sending history messages.  Now it will update its online status every time it reads a message of any kind. 
